### PR TITLE
Add MPAA Rating Update for Movies

### DIFF
--- a/default.py
+++ b/default.py
@@ -5,6 +5,7 @@
 
 from resources.lib.top250 import Top250
 from resources.lib.movies import Movies
+from resources.lib.mpaa import Mpaa
 from resources.lib.util import *
 import sys
 import time
@@ -12,7 +13,7 @@ import time
 def gui():
     stop = False
     while not(stop):
-        choice = dialogSelect(addOnVersion, [l("Top250"), l("Movies"), l("Show Top250"), l("Exit")])
+        choice = dialogSelect(addOnVersion, [l("Top250"), l("Movies"), l("Show Top250"), l("MPAA Update"), l("Exit")])
         if choice == 0:
             stop = Top250().start()
         elif choice == 1:
@@ -20,6 +21,8 @@ def gui():
         elif choice == 2:
             xbmc.executebuiltin('XBMC.ActivateWindow(10025,special://home/addons/script.imdbupdate/resources/Top250.xsp,return)')
             break
+        elif choice == 3:
+            stop = Mpaa().start()
         else:
             break
 

--- a/resources/lib/imdbmpaa.py
+++ b/resources/lib/imdbmpaa.py
@@ -1,0 +1,50 @@
+################
+# MPAA Update  #
+# by semool    #
+################
+
+import httplib, socket, json
+
+class imdbMpaa(object):
+    
+    def __init__(self, imdbID, httphandler, LANG_MPAA):
+        self.__rating = ""
+        self.__error = False
+        self.__imdbID = imdbID
+        self.__Lang = LANG_MPAA
+        
+        self.getData(httphandler)
+
+    def getData(self, httphandler):
+        try:
+            if self.__Lang == "DE":
+                httphandler.request("GET", "/api/imdb_id/%s" % self.__imdbID)
+            if self.__Lang == "US":
+                httphandler.request("GET", "/?i=%s" % self.__imdbID)
+            response = httphandler.getresponse()
+        except (httplib.HTTPException, socket.timeout, socket.gaierror, socket.error):
+            self.__error = True
+        else:
+            if response.status == 200:
+                try:
+                    if self.__Lang == "DE":
+                       data = json.loads(response.read().decode('utf8'))
+                       data = str(data)
+                       if data == "100" or data == "200" or data == "300":
+                          self.__error = True
+                       else:
+                          self.__rating = data
+                    if self.__Lang == "US":
+                      data = json.loads(response.read().decode('utf8'))
+                      if "error" in data or data["Response"] == "False":
+                        self.__error = True
+                      else:
+                        self.__rating = str(data["Rated"])
+                except:
+                    self.__error = True
+            else:
+                self.__error = True
+    
+    def rating(self):   return self.__rating
+    def error(self):    return self.__error
+    def imdbID(self):   return self.__imdbID

--- a/resources/lib/mpaa.py
+++ b/resources/lib/mpaa.py
@@ -1,0 +1,77 @@
+################
+# MPAA Update  #
+# by semool    #
+################
+
+from util import *
+from imdbmpaa import imdbMpaa
+import httplib
+
+HIDE_MPAA = settingBool("hideMpaa")
+LANG_MPAA = addOn.getSetting("mpaaLang")
+FORM_MPAA = addOn.getSetting("mpaaFormat")
+
+class Mpaa:
+    def start(self, hidden=False):
+        if hidden:
+            global HIDE_MPAA
+            HIDE_MPAA = True
+        movies = getMoviesWith('imdbnumber', 'mpaa')
+        total = len(movies)
+        if total > 0:
+            self.startProcess(movies, total)
+        else:
+            dialogOk(l("Info"), l("The_video_library_is_empty_or_the_IMDb_id_doesn't_exist!"))
+        return HIDE_MPAA
+
+    def startProcess(self, movies, total):
+        updated = 0
+        resume = 0
+        if HIDE_MPAA:
+            notification(l("Started_updating_movies_ratings"))
+        else:
+            progress = dialogProgress()
+        if LANG_MPAA == "DE":
+            SITEUSE = "altersfreigaben.de"
+        if LANG_MPAA == "US":
+            SITEUSE = "www.omdbapi.com"
+        httphandler = httplib.HTTPConnection(SITEUSE)
+        for count, movie in enumerate(movies):
+            if abortRequested() or (not(HIDE_MPAA) and progress.iscanceled()):
+                break
+            if not(HIDE_MPAA):
+                progress.update((count * 100) // total, "%s %s" % (l("Searching_for"), movie["label"]))
+            updated += self.updateMovie(movie, httphandler, LANG_MPAA)
+        text = "%s: %s %s %s %s!" % (l("Movies_ratings_summary"), updated, l("of"), total, l("were_updated"))
+        log(text)
+        if HIDE_MPAA:
+            notification(text)
+        else:
+            progress.close()
+            dialogOk(l("Completed"), text)
+                
+    def updateMovie(self, movie, httphandler, LANG_MPAA):
+        result = 0
+        if movie["imdbnumber"] == "":
+            log("%s: %s" % (movie["label"], l("IMDb_id_was_not_found_in_your_database!")))
+        else:
+            mpaa = imdbMpaa(movie["imdbnumber"], httphandler, LANG_MPAA)
+            if ":" in FORM_MPAA:
+                FINAL_RATING = "%s%s" % (FORM_MPAA, mpaa.rating())
+            else:
+            	  FINAL_RATING = "%s %s" % (FORM_MPAA, mpaa.rating())
+            if mpaa.error():
+                log("%s: %s" % (movie["label"], l("There_was_a_problem_with_the_MPAA_site!")))
+            elif not(self.shouldUpdate(movie, FINAL_RATING)):
+                log("%s: %s" % (movie["label"], l("Nothing_to_do_has_already_been_updated!")))
+            else:
+                executeJSON('VideoLibrary.SetMovieDetails', {'movieid':movie['movieid'], 'mpaa':FINAL_RATING})
+                log("%s: %s %s" % (movie["label"], l("was_updated_to"), FINAL_RATING))
+                result = 1
+        return result
+
+    def shouldUpdate(self, old, new):
+        oldRating = old["mpaa"]
+        newRating = new
+        result = oldRating != newRating
+        return result

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,6 +5,9 @@
 	<setting id="enableDiff"	type="bool"		default="true"	label="enable rating difference" />
 	<setting id="hideMovies"	type="bool"		default="false"	label="hide movie progress" />
 	<setting id="hideTop250"	type="bool"		default="false"	label="hide Top250 progress" />
+	<setting id="hideMpaa"	type="bool"		default="false"	label="hide Mpaa progress" />
+	<setting id="mpaaLang"	type="labelenum"		values="DE|US"	default="DE"	label="Mpaa Language"/>
+	<setting id="mpaaFormat"	type="labelenum"		values="Rated|USA:|FSK|Germany:"	default="Rated"	label="Mpaa Format"/>
 	<setting id="deamonMovies"	type="bool"		default="false"	label="run Movies periodically (weekly)" />
 	<setting id="deamonTop250"	type="bool"		default="false"	label="run Top250 periodically (weekly)" />
 </settings>


### PR DESCRIPTION
MPAA Language: DE or US - DE comes from altersfreigabe.de, US comes from omdb
MPAA Format: Rated|USA:|FSK|Germany: - Format as it save to Database (germany: 6, FSK 6, Rated R and so on)
Also the Database will only be updated if the new and old variable are different.
